### PR TITLE
Added auth services

### DIFF
--- a/ChatApp.Application/Commands/Auth/LoginCommand.cs
+++ b/ChatApp.Application/Commands/Auth/LoginCommand.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace ChatApp.Application.Commands.Auth;
+
+public record LoginCommand(string Username, string Password) : IRequest<LoginResponse>;
+
+public record LoginResponse(string Token, string Username); 

--- a/ChatApp.Application/Commands/Auth/LoginCommandHandler.cs
+++ b/ChatApp.Application/Commands/Auth/LoginCommandHandler.cs
@@ -1,0 +1,39 @@
+using ChatApp.Application.Interfaces;
+using MediatR;
+
+namespace ChatApp.Application.Commands.Auth;
+
+public class LoginCommandHandler : IRequestHandler<LoginCommand, LoginResponse>
+{
+    private readonly IUserRepository _userRepository;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly IJwtService _jwtService;
+
+    public LoginCommandHandler(
+        IUserRepository userRepository,
+        IPasswordHasher passwordHasher,
+        IJwtService jwtService)
+    {
+        _userRepository = userRepository;
+        _passwordHasher = passwordHasher;
+        _jwtService = jwtService;
+    }
+
+    public async Task<LoginResponse> Handle(LoginCommand request, CancellationToken cancellationToken)
+    {
+        var user = await _userRepository.GetByUsernameAsync(request.Username);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException("Invalid username or password");
+        }
+
+        var isPasswordValid = _passwordHasher.VerifyPassword(request.Password, user.PasswordHash);
+        if (!isPasswordValid)
+        {
+            throw new UnauthorizedAccessException("Invalid username or password");
+        }
+
+        var token = _jwtService.GenerateToken(user);
+        return new LoginResponse(token, user.Username);
+    }
+} 

--- a/ChatApp.Application/Interfaces/IJwtService.cs
+++ b/ChatApp.Application/Interfaces/IJwtService.cs
@@ -1,0 +1,8 @@
+using ChatApp.Domain.Entities;
+
+namespace ChatApp.Application.Interfaces;
+
+public interface IJwtService
+{
+    string GenerateToken(User user);
+} 

--- a/ChatApp.Application/Settings/JwtSettings.cs
+++ b/ChatApp.Application/Settings/JwtSettings.cs
@@ -1,0 +1,9 @@
+namespace ChatApp.Application.Settings;
+
+public class JwtSettings
+{
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = string.Empty;
+    public int ExpiryMinutes { get; set; }
+} 

--- a/ChatApp.Infrastructure/ChatApp.Infrastructure.csproj
+++ b/ChatApp.Infrastructure/ChatApp.Infrastructure.csproj
@@ -15,7 +15,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.11.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ChatApp.Infrastructure/DependencyInjection.cs
+++ b/ChatApp.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using ChatApp.Application.Interfaces;
+using ChatApp.Application.Settings;
 using ChatApp.Infrastructure.Persistence;
 using ChatApp.Infrastructure.Repositories;
 using ChatApp.Infrastructure.Services;
@@ -20,6 +21,11 @@ public static class DependencyInjection
         services.AddScoped<IMessageRepository, MessageRepository>();
         services.AddScoped<IPasswordHasher, PasswordHasher>();
         services.AddScoped<ChatAppDbInitializer>();
+
+        // Configure JWT
+        var jwtSettings = configuration.GetSection("JwtSettings").Get<JwtSettings>();
+        services.AddSingleton(jwtSettings);
+        services.AddScoped<IJwtService, JwtService>();
         
         return services;
     }

--- a/ChatApp.Infrastructure/Services/JwtService.cs
+++ b/ChatApp.Infrastructure/Services/JwtService.cs
@@ -1,0 +1,41 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using ChatApp.Application.Interfaces;
+using ChatApp.Application.Settings;
+using ChatApp.Domain.Entities;
+using Microsoft.IdentityModel.Tokens;
+
+namespace ChatApp.Infrastructure.Services;
+
+public class JwtService : IJwtService
+{
+    private readonly JwtSettings _jwtSettings;
+
+    public JwtService(JwtSettings jwtSettings)
+    {
+        _jwtSettings = jwtSettings;
+    }
+
+    public string GenerateToken(User user)
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new Claim(ClaimTypes.Name, user.Username)
+        };
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.SecretKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _jwtSettings.Issuer,
+            audience: _jwtSettings.Audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(_jwtSettings.ExpiryMinutes),
+            signingCredentials: credentials
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+} 

--- a/ChatApp.WebApi/ChatApp.WebApi.csproj
+++ b/ChatApp.WebApi/ChatApp.WebApi.csproj
@@ -8,7 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/ChatApp.WebApi/appsettings.json
+++ b/ChatApp.WebApi/appsettings.json
@@ -1,4 +1,13 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=chatapp;Username=postgres;Password=postgres"
+  },
+  "JwtSettings": {
+    "Issuer": "ChatApp",
+    "Audience": "ChatApp",
+    "SecretKey": "your-256-bit-secret-key-here-make-it-long-and-secure",
+    "ExpiryMinutes": 60
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
I want you to extend the existing ChatApp backend (.NET 9, Minimal API, Clean Architecture) to support proper Authentication and Authorization.

Requirements:
Implement JWT-based Authentication:
Use Microsoft.AspNetCore.Authentication.JwtBearer
Add /auth/login endpoint that accepts username + password and returns a JWT token
Passwords must be hashed and stored securely (use BCrypt or ASP.NET Core PasswordHasher)
Use ASP.NET Core Identity PasswordHasher if possible for hashing (without using full Identity system)
During user registration, hash the password before saving to DB.
Add JWT authentication middleware to the WebApi pipeline.
All API endpoints except:
/health
/users/register
/auth/login
should require a valid JWT token ([Authorize] or Minimal API equivalent).

Add /users/me endpoint:
Returns current authenticated user’s profile (id, username, etc.)
Uses the JWT token to determine the current user.
Keep using Clean Architecture principles:
No auth logic should leak into Domain layer
User password hashing should happen in Application layer or Infrastructure service
JWT settings should be in configuration (Issuer, Audience, Secret Key)
Provide the necessary extension methods for registering JWT Auth in DI:
Example: services.AddJwtAuthentication(configuration)
Update Swagger to support JWT bearer token (Authorize button).
The goal is to have full JWT auth flow:
User registers
User logs in → receives JWT token
User accesses protected endpoints using Authorization: Bearer <token>

Project context:
ChatApp backend already exists:
Clean Architecture split into: Domain, Application, Infrastructure, WebApi
Minimal API in WebApi
MediatR for Commands/Queries
PostgreSQL for persistence
Additional Notes:
Do NOT use full ASP.NET Identity system, just PasswordHasher and JWT auth.
All code should match existing clean architecture style.